### PR TITLE
art: Patch dex checksums in the right order

### DIFF
--- a/app/src/main/java/me/hexile/odexpatcher/art/ArtPatcher.kt
+++ b/app/src/main/java/me/hexile/odexpatcher/art/ArtPatcher.kt
@@ -34,7 +34,7 @@ abstract class ArtPatcher(private val file: File) {
         }
     }
 
-    fun patch(checksums: ArrayList<ByteArray>) {
+    fun patch(checksums: HashMap<String, ByteArray>) {
         if (checksums.isEmpty()) {
             throw IllegalArgumentException("Cannot be empty")
         } else if (checksums.size != this._checksums.size) {
@@ -47,12 +47,15 @@ abstract class ArtPatcher(private val file: File) {
 
                 val source = raf.readBytes(it.value.first, 4)
                 val sourceCache = it.value.second
-                val new = checksums[it.index]
+                // Retrieve the correct checksum based on the dex name from the map.
+                // Example - { "classes1.dex": "checksum" , ... }
+                // so index + 1 is needed here.
+                val new = checksums["classes${it.index + 1}.dex"]
 
-                println(" -> ${source.toHexString()} = ${new.toHexString()} [${sourceCache.toHexString()}]")
+                println(" -> ${source.toHexString()} = ${new?.toHexString()} [${sourceCache.toHexString()}]")
 
                 raf.seek(it.value.first)
-                raf.write(checksums[it.index]) // java.lang.IndexOutOfBoundsException: Invalid index 0, size is 0
+                raf.write(new) // java.lang.IndexOutOfBoundsException: Invalid index 0, size is 0
             }
         }
     }

--- a/app/src/main/java/me/hexile/odexpatcher/ktx/CollectionsExt.kt
+++ b/app/src/main/java/me/hexile/odexpatcher/ktx/CollectionsExt.kt
@@ -40,7 +40,7 @@ fun List<ByteArray>.toHexString(): String {
     }
 }
 
-fun Map<Long, ByteArray>.toHexString(): String {
+fun HashMap<String, ByteArray>.toHexString(): String {
     return this.iterator().let {
         if (!it.hasNext()) {
             "{}"

--- a/app/src/main/java/me/hexile/odexpatcher/utils/Utils.kt
+++ b/app/src/main/java/me/hexile/odexpatcher/utils/Utils.kt
@@ -20,7 +20,6 @@ import android.os.Build
 import androidx.lifecycle.MutableLiveData
 import me.hexile.odexpatcher.ktx.toByteArray
 import java.io.File
-import java.util.*
 import java.util.zip.ZipFile
 
 fun isSdkGreaterThan(version: Int): Boolean {
@@ -41,36 +40,23 @@ fun <T> MutableLiveData<T>.notifyObserver() {
     this.value = this.value
 }
 
-fun extractChecksums(file: File): ArrayList<ByteArray> { // Map<String, ByteArray> {
+fun extractChecksums(file: File): HashMap<String, ByteArray> {
     return extractClassesDex(file.absolutePath)
 }
 
-fun extractClassesDex(path: String): ArrayList<ByteArray> { //Map<String, ByteArray> {
-    /*val classesDex = LinkedHashMap<String, ByteArray>()
+fun extractClassesDex(path: String): HashMap<String, ByteArray> {
+    val checksums = hashMapOf<String, ByteArray>()
     ZipFile(path).use { zip ->
         zip
             .entries()
             .asSequence()
             .forEach {
                 if (it.name.startsWith("classes") && it.name.endsWith(".dex")) {
-                    classesDex[it.name] = it.crc.toInt().toByteArray()
+                    // Add classes.dex as classes1.dex for ordering purpose while patching.
+                    val dexName = if (it.name == "classes.dex") "classes1.dex" else it.name
+                    checksums[dexName] = it.crc.toInt().toByteArray()
                 }
             }
     }
-    return classesDex*/
-    val checksums = ArrayList<ByteArray>()
-
-    ZipFile(path).use { zip ->
-        zip
-            .entries()
-            .asSequence()
-            .forEach {
-                if (it.name.startsWith("classes") && it.name.endsWith(".dex")) {
-                    //println(it.name)
-                    checksums.add(it.crc.toInt().toByteArray())
-                }
-            }
-    }
-
     return checksums
 }


### PR DESCRIPTION
dex checksums are present in the oat/vdex files in this order - classes.dex, classes1.dex,..., classesN.dex. So ensure the order while patching.